### PR TITLE
Upgrade Turf & Optimizations

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,8 @@
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.min.js"></script>
 
     <!-- Turf.js -->
-    <script src='https://api.tiles.mapbox.com/mapbox.js/plugins/turf/v3.0.11/turf.min.js'></script>
+    <!-- <script src='https://api.tiles.mapbox.com/mapbox.js/plugins/turf/v3.0.11/turf.min.js'></script> -->
+    <script src='https://unpkg.com/@turf/turf@6.3.0/turf.min.js'></script>
 
     <!-- Mapbox Directions -->
     <script src='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-directions/v3.1.1/mapbox-gl-directions.js'></script>

--- a/src/app.js
+++ b/src/app.js
@@ -124,6 +124,7 @@ function getIsochroneURL(modality, time, long, lat) {
         "?contours_minutes=" +
         time +
         "&polygons=true" +
+        "&generalize=5" +
         "&access_token=" +
         mapboxgl.accessToken;
 
@@ -227,7 +228,7 @@ function getIntersection() {
     // console.log(intersection);
 
     let intersection = land.reduce((collect, feature, i)=>{
-        if (turf.intersect(feature, isoResult)){
+        if (turf.booleanIntersects(feature, isoResult)){
             collect.push(feature)
         }
         return collect;
@@ -236,7 +237,7 @@ function getIntersection() {
     
     // // Populate the intersection map layer
     // This should be ok with an empty array also from above, if you want to skip the conditional
-    MAP.getSource("intersection").setData(turf.featureCollection(intersection););
+    MAP.getSource("intersection").setData(turf.featureCollection(intersection));
     // console.log("intersection source defined");
     // } else {
     //   MAP.getSource("intersection").setData({


### PR DESCRIPTION
A few optimizations, thanks to some help from J Brannigan (he says hey)
* Upgrade turf to latest version
* Use booleanIntersects instead of intersect since we don't need the intersecting geometry
* Generalize the isochrones using `generalize=5` for performance -- if this results in self-intersections you could also `turf.simplify`. Try experimenting with this value to get a good tradeoff between speed and detail in the shapes.